### PR TITLE
Remove unneeded peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -353,7 +353,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
       "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.1.2"
       }
@@ -922,8 +921,7 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-popper": {
       "version": "1.3.3",
@@ -939,13 +937,12 @@
       }
     },
     "react-transition-group": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.3.tgz",
-      "integrity": "sha512-2DGFck6h99kLNr8pOFk+z4Soq3iISydwOFeeEVPjTN6+Y01CmvbWmnN02VuTWyFdnRtIDPe+wy2q6Ui8snBPZg==",
-      "dev": true,
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
+      "integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
       "requires": {
         "dom-helpers": "^3.3.1",
-        "loose-envify": "^1.4.0",
+        "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
         "react-lifecycles-compat": "^3.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "mobx-react": "^5.1.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
-    "react-transition-group": "^2.4.0",
     "rimraf": "^2.6.2",
     "styled-components": "^3.4.2",
     "tslib": "^1.9.3",
@@ -46,15 +45,14 @@
     "@puzzl/browser": "^1.0.0-beta.1",
     "@puzzl/core": "^1.0.0-beta.1",
     "datetime-difference": "^1.0.1",
-    "react-popper": "^1.0.2"
+    "react-popper": "^1.0.2",
+    "react-transition-group": "^2.4.0"
   },
   "peerDependencies": {
-    "bignumber.js": ">=8.0.1",
     "mobx": ">=4.3.0",
     "mobx-react": ">=5.1.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
-    "react-transition-group": "^2.4.0",
     "styled-components": "^3.4.2"
   }
 }


### PR DESCRIPTION
- bignumber.js was used only at build time
- react-transition-group can be used internally just as well.